### PR TITLE
Liquid upgrade

### DIFF
--- a/condensation.gemspec
+++ b/condensation.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'liquid', ['>= 2.0', '<= 4.0']
+  spec.add_dependency 'liquid', '~> 4.0.3'
   spec.add_dependency 'tzinfo', '~> 1'
   spec.add_dependency 'activesupport', '>= 3.0'
 end


### PR DESCRIPTION
Fix liquid errors after ruby 2.7.2 upgrade.

## Testing

`rake test`