### PR TITLE
[SMS-793] Change dependencies so monolith can upgrade liquid gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Version 1.5.1
+
+*June 21, 2022*
+
+- Bump liquid dependency from `4.0.3` to `5.3.0`
+- Drop tzinfo dependency from `1` to `1.1`

--- a/condensation.gemspec
+++ b/condensation.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'liquid', '~> 4.0.3'
-  spec.add_dependency 'tzinfo', '~> 2'
+  spec.add_dependency 'liquid', '~> 5.3.0'
+  spec.add_dependency 'tzinfo', '~> 1.1'
   spec.add_dependency 'activesupport', '>= 3.0'
 end

--- a/lib/condensation/version.rb
+++ b/lib/condensation/version.rb
@@ -1,3 +1,3 @@
 module Condensation
-  VERSION = '1.6.0'.freeze
+  VERSION = "1.5.1".freeze
 end


### PR DESCRIPTION
Just throwing this out there based on an earlier conversation in Slack.

The `tzinfo` change was needed to get the monolith version of rails to run `bundle update condensation liquid` without an error. Without the `tzinfo` change, this error occurs when trying to update condensation:
```
Bundler could not find compatible versions for gem "tzinfo":
  In Gemfile:
    rails (= 6.0.4.4) was resolved to 6.0.4.4, which depends on
      activesupport (= 6.0.4.4) was resolved to 6.0.4.4, which depends on
        tzinfo (~> 1.1)
```